### PR TITLE
Restaurant Creation

### DIFF
--- a/src/main/java/org/qrush/brand/GlobalExceptionHandler.java
+++ b/src/main/java/org/qrush/brand/GlobalExceptionHandler.java
@@ -1,6 +1,9 @@
-package org.qrush.brand.brand.exceptions;
+package org.qrush.brand;
 
 import org.hibernate.service.spi.ServiceException;
+import org.qrush.brand.brand.exceptions.BrandAlreadyExists;
+import org.qrush.brand.brand.exceptions.BrandNotFoundException;
+import org.qrush.brand.restaurant.exceptions.RestaurantAlreadyExists;
 import org.springframework.http.*;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -28,6 +31,12 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         problemDetail.setInstance(URI.create(request.getContextPath()));
         return problemDetail;
     }
+
+    @ExceptionHandler(RestaurantAlreadyExists.class)
+    public ProblemDetail handleRestaurantAlreadyExists(RestaurantAlreadyExists ex, WebRequest request) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, ex.getMessage());
+        problemDetail.setInstance(URI.create(request.getContextPath()));
+        return problemDetail;    }
 
     @Override
     protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode statusCode, WebRequest request) {

--- a/src/main/java/org/qrush/brand/brand/dto/BrandDto.java
+++ b/src/main/java/org/qrush/brand/brand/dto/BrandDto.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import jakarta.validation.constraints.NotEmpty;
+import org.qrush.brand.brand.models.Brand;
 
 @Data
 @Builder
@@ -17,4 +18,11 @@ public class BrandDto {
 
     @NotEmpty(message = "Brand name cannot be null or empty")
     private String name;
+
+    public Brand toBrand () {
+        return Brand.builder()
+                .name(name)
+                .id(id)
+                .build();
+    }
 }

--- a/src/main/java/org/qrush/brand/brand/helpers/BrandMapper.java
+++ b/src/main/java/org/qrush/brand/brand/helpers/BrandMapper.java
@@ -1,0 +1,22 @@
+package org.qrush.brand.brand.helpers;
+
+import org.qrush.brand.brand.dto.BrandDto;
+import org.qrush.brand.brand.models.Brand;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BrandMapper {
+    public Brand toEntity(BrandDto brandDto) {
+        return Brand.builder()
+                .name(brandDto.getName())
+                .id(brandDto.getId())
+                .build();
+    }
+
+    public BrandDto toDTO(Brand brand) {
+        return BrandDto.builder()
+                .id(brand.getId())
+                .name(brand.getName())
+                .build();
+    }
+}

--- a/src/main/java/org/qrush/brand/brand/helpers/BrandMapper.java
+++ b/src/main/java/org/qrush/brand/brand/helpers/BrandMapper.java
@@ -7,16 +7,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class BrandMapper {
     public Brand toEntity(BrandDto brandDto) {
-        return Brand.builder()
-                .name(brandDto.getName())
-                .id(brandDto.getId())
-                .build();
+        return brandDto.toBrand();
     }
 
     public BrandDto toDTO(Brand brand) {
-        return BrandDto.builder()
-                .id(brand.getId())
-                .name(brand.getName())
-                .build();
+        return brand.toDto();
     }
 }

--- a/src/main/java/org/qrush/brand/brand/models/Brand.java
+++ b/src/main/java/org/qrush/brand/brand/models/Brand.java
@@ -6,7 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
+import org.qrush.brand.brand.dto.BrandDto;
 
 
 @Data
@@ -23,6 +23,13 @@ public class Brand {
     @Column(unique= true)
     @NotEmpty(message = "Brand name cannot be null or empty")
     private String name;
+
+    public BrandDto toDto() {
+        return BrandDto.builder()
+                .name(name)
+                .id(id)
+                .build();
+    }
 }
 
 

--- a/src/main/java/org/qrush/brand/restaurant/RestaurantController.java
+++ b/src/main/java/org/qrush/brand/restaurant/RestaurantController.java
@@ -7,7 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/brand/{brand_id}")
+@RequestMapping("/brand/{brand_id}/restaurant")
 public class RestaurantController {
     private final RestaurantService restaurantService;
 

--- a/src/main/java/org/qrush/brand/restaurant/RestaurantController.java
+++ b/src/main/java/org/qrush/brand/restaurant/RestaurantController.java
@@ -1,0 +1,23 @@
+package org.qrush.brand.restaurant;
+
+import jakarta.validation.Valid;
+import org.qrush.brand.restaurant.dto.RestaurantDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/brand/{brand_id}")
+public class RestaurantController {
+    private final RestaurantService restaurantService;
+
+    public RestaurantController(RestaurantService restaurantService) {
+        this.restaurantService = restaurantService;
+    }
+
+    @PostMapping()
+    public ResponseEntity<RestaurantDto> createRestaurant(@PathVariable("brand_id") Long brandId, @RequestBody @Valid RestaurantDto restaurantDto) {
+        restaurantDto.setBrandId(brandId);
+        return new ResponseEntity<>(restaurantService.createRestaurant(restaurantDto), HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/org/qrush/brand/restaurant/RestaurantRepository.java
+++ b/src/main/java/org/qrush/brand/restaurant/RestaurantRepository.java
@@ -1,0 +1,11 @@
+package org.qrush.brand.restaurant;
+
+import org.qrush.brand.restaurant.models.Restaurant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface RestaurantRepository extends JpaRepository<Restaurant, UUID> {
+    Optional<Restaurant> findByNameAndBrandId(String name, Long brandId);
+}

--- a/src/main/java/org/qrush/brand/restaurant/RestaurantService.java
+++ b/src/main/java/org/qrush/brand/restaurant/RestaurantService.java
@@ -1,0 +1,42 @@
+package org.qrush.brand.restaurant;
+
+import org.qrush.brand.brand.BrandService;
+import org.qrush.brand.brand.dto.BrandDto;
+import org.qrush.brand.brand.helpers.BrandMapper;
+import org.qrush.brand.brand.models.Brand;
+import org.qrush.brand.restaurant.dto.RestaurantDto;
+import org.qrush.brand.restaurant.exceptions.RestaurantAlreadyExists;
+import org.qrush.brand.restaurant.helpers.RestaurantMapper;
+import org.qrush.brand.restaurant.models.Restaurant;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RestaurantService {
+
+    private final RestaurantRepository restaurantRepository;
+    private final BrandService brandService;
+    private final RestaurantMapper restaurantMapper;
+    private final BrandMapper brandMapper;
+
+    public RestaurantService(RestaurantRepository restaurantRepository, BrandService brandService, RestaurantMapper restaurantMapper, BrandMapper brandMapper) {
+        this.restaurantRepository = restaurantRepository;
+        this.brandService = brandService;
+        this.restaurantMapper = restaurantMapper;
+        this.brandMapper = brandMapper;
+    }
+
+    public RestaurantDto createRestaurant(RestaurantDto restaurantDto) {
+        BrandDto brandDto = brandService.getBrandById(restaurantDto.getBrandId());
+        Brand brand = brandMapper.toEntity(brandDto);
+
+        if (restaurantRepository.findByNameAndBrandId(restaurantDto.getName(), restaurantDto.getBrandId()).orElse(null) != null) {
+            throw new RestaurantAlreadyExists(String.format("Restaurant name already exists for brand %s", brand.getName()));
+        }
+
+        Restaurant restaurant = restaurantMapper.toEntity(restaurantDto, brand);
+
+        Restaurant savedRestaurant = restaurantRepository.save(restaurant);
+
+        return restaurantMapper.toDTO(savedRestaurant);
+    }
+}

--- a/src/main/java/org/qrush/brand/restaurant/dto/RestaurantDto.java
+++ b/src/main/java/org/qrush/brand/restaurant/dto/RestaurantDto.java
@@ -8,6 +8,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.qrush.brand.brand.models.Brand;
+import org.qrush.brand.restaurant.models.Restaurant;
+import org.springframework.data.geo.Point;
 
 import java.util.UUID;
 
@@ -36,4 +39,16 @@ public class RestaurantDto {
     private Double longitude;
 
     private Long brandId;
+
+    public Restaurant toRestaurant(Brand brand) {
+        //ToDo: does this need logic to check brand matches brand id??
+        return Restaurant.builder()
+                .id(id)
+                .name(name)
+                .address(address)
+                .location(new Point(longitude, latitude))
+                .brand(brand)
+                .build();
+
+    }
 }

--- a/src/main/java/org/qrush/brand/restaurant/dto/RestaurantDto.java
+++ b/src/main/java/org/qrush/brand/restaurant/dto/RestaurantDto.java
@@ -1,0 +1,39 @@
+package org.qrush.brand.restaurant.dto;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class RestaurantDto {
+
+    private UUID id;
+
+    @NotEmpty(message = "Restaurant name cannot be null or empty")
+    private String name;
+
+    @NotEmpty(message = "Restaurant address cannot be null or empty")
+    private String address;
+
+    @NotNull(message = "Restaurant latitude cannot be null")
+    @DecimalMin(value = "-90.0", message = "Latitude must be between -90 and 90")
+    @DecimalMax(value = "90.0", message = "Latitude must be between -90 and 90")
+    private Double latitude;
+
+    @NotNull(message = "Restaurant longitude cannot be null")
+    @DecimalMin(value = "-180.0", message = "Longitude must be between -180 and 180")
+    @DecimalMax(value = "180.0", message = "Longitude must be between -180 and 180")
+    private Double longitude;
+
+    private Long brandId;
+}

--- a/src/main/java/org/qrush/brand/restaurant/exceptions/RestaurantAlreadyExists.java
+++ b/src/main/java/org/qrush/brand/restaurant/exceptions/RestaurantAlreadyExists.java
@@ -1,0 +1,7 @@
+package org.qrush.brand.restaurant.exceptions;
+
+public class RestaurantAlreadyExists extends RuntimeException {
+    public RestaurantAlreadyExists(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/qrush/brand/restaurant/helpers/RestaurantMapper.java
+++ b/src/main/java/org/qrush/brand/restaurant/helpers/RestaurantMapper.java
@@ -1,0 +1,30 @@
+package org.qrush.brand.restaurant.helpers;
+
+import org.qrush.brand.brand.models.Brand;
+import org.qrush.brand.restaurant.dto.RestaurantDto;
+import org.qrush.brand.restaurant.models.Restaurant;
+import org.springframework.data.geo.Point;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RestaurantMapper {
+    public Restaurant toEntity(RestaurantDto restaurantDto, Brand brand) {
+        return Restaurant.builder()
+                .name(restaurantDto.getName())
+                .brand(brand)
+                .address(restaurantDto.getAddress())
+                .location(new Point(restaurantDto.getLongitude(), restaurantDto.getLatitude()))
+                .build();
+    }
+
+    public RestaurantDto toDTO(Restaurant restaurant) {
+        return RestaurantDto.builder()
+                .id(restaurant.getId())
+                .name(restaurant.getName())
+                .brandId(restaurant.getBrand().getId())
+                .address(restaurant.getAddress())
+                .latitude(restaurant.getLocation().getY())
+                .longitude(restaurant.getLocation().getX())
+                .build();
+    }
+}

--- a/src/main/java/org/qrush/brand/restaurant/helpers/RestaurantMapper.java
+++ b/src/main/java/org/qrush/brand/restaurant/helpers/RestaurantMapper.java
@@ -3,28 +3,15 @@ package org.qrush.brand.restaurant.helpers;
 import org.qrush.brand.brand.models.Brand;
 import org.qrush.brand.restaurant.dto.RestaurantDto;
 import org.qrush.brand.restaurant.models.Restaurant;
-import org.springframework.data.geo.Point;
 import org.springframework.stereotype.Component;
 
 @Component
 public class RestaurantMapper {
     public Restaurant toEntity(RestaurantDto restaurantDto, Brand brand) {
-        return Restaurant.builder()
-                .name(restaurantDto.getName())
-                .brand(brand)
-                .address(restaurantDto.getAddress())
-                .location(new Point(restaurantDto.getLongitude(), restaurantDto.getLatitude()))
-                .build();
+        return restaurantDto.toRestaurant(brand);
     }
 
     public RestaurantDto toDTO(Restaurant restaurant) {
-        return RestaurantDto.builder()
-                .id(restaurant.getId())
-                .name(restaurant.getName())
-                .brandId(restaurant.getBrand().getId())
-                .address(restaurant.getAddress())
-                .latitude(restaurant.getLocation().getY())
-                .longitude(restaurant.getLocation().getX())
-                .build();
+        return restaurant.toDto();
     }
 }

--- a/src/main/java/org/qrush/brand/restaurant/models/Restaurant.java
+++ b/src/main/java/org/qrush/brand/restaurant/models/Restaurant.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.qrush.brand.brand.models.Brand;
+import org.qrush.brand.restaurant.dto.RestaurantDto;
 import org.springframework.data.geo.Point;
 
 import java.util.UUID;
@@ -41,4 +42,15 @@ public class Restaurant {
     @ManyToOne
     @JoinColumn(name = "brand_id")
     private Brand brand;
+
+    public RestaurantDto toDto() {
+        return RestaurantDto.builder()
+                .id(id)
+                .name(name)
+                .address(address)
+                .longitude(location.getX())
+                .latitude(location.getY())
+                .brandId(brand.getId())
+                .build();
+    }
 }

--- a/src/main/java/org/qrush/brand/restaurant/models/Restaurant.java
+++ b/src/main/java/org/qrush/brand/restaurant/models/Restaurant.java
@@ -1,0 +1,44 @@
+package org.qrush.brand.restaurant.models;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.qrush.brand.brand.models.Brand;
+import org.springframework.data.geo.Point;
+
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+@Table(
+        name = "restaurants",
+        uniqueConstraints = @UniqueConstraint(name = "Unique restaurant name for each brand", columnNames = {"name", "brand_id"})
+)
+public class Restaurant {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    @NotEmpty(message = "Restaurant name cannot be null or empty")
+    private String name;
+
+    @Column(nullable = false)
+    @NotEmpty(message = "Restaurant address cannot be null or empty")
+    private String address;
+
+    @Column(nullable = false)
+    @NotNull(message = "Restaurant location cannot be null")
+    private Point location;
+
+    @ManyToOne
+    @JoinColumn(name = "brand_id")
+    private Brand brand;
+}

--- a/src/test/java/org/qrush/brand/integration/RestaurantControllerIntegrationTests.java
+++ b/src/test/java/org/qrush/brand/integration/RestaurantControllerIntegrationTests.java
@@ -27,12 +27,14 @@ public class RestaurantControllerIntegrationTests extends AbstractIntegrationTes
     private RestaurantDto restaurantDto;
     private Brand brand;
     private Brand savedBrand;
+    private String url;
 
     @PostConstruct
     public void setup() {
         restaurantDto = generateRestaurantDto();
         brand = generateBrand();
         savedBrand = brandRepository.save(brand);
+        url = BRAND_API_ENDPOINT + "/" + savedBrand.getId().toString() + "/restaurant";
     }
 
     // region POST
@@ -40,7 +42,7 @@ public class RestaurantControllerIntegrationTests extends AbstractIntegrationTes
     @DisplayName("Happy Path Test: create and return restaurant")
     void restaurantControllerIntegration_CreateRestaurant_ReturnsRestaurantDto() throws Exception {
 
-        RestaurantDto createdRestaurant = performPostRequestExpectedSuccess(BRAND_API_ENDPOINT + "/" + savedBrand.getId().toString(), restaurantDto, RestaurantDto.class);
+        RestaurantDto createdRestaurant = performPostRequestExpectedSuccess(url, restaurantDto, RestaurantDto.class);
 
         assertNotNull(createdRestaurant);
         assertNotNull(createdRestaurant.getId());
@@ -56,7 +58,7 @@ public class RestaurantControllerIntegrationTests extends AbstractIntegrationTes
     void restaurantControllerIntegration_CreateRestaurant_GivenEmptyRestaurantName_ReturnsBadRequest() throws Exception {
         restaurantDto.setName("");
 
-        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(BRAND_API_ENDPOINT + "/" + savedBrand.getId(), restaurantDto, ExtendedProblemDetails.class);
+        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(url, restaurantDto, ExtendedProblemDetails.class);
 
         assertNotNull(problemDetail);
         assertEquals(HttpStatus.BAD_REQUEST.value(), problemDetail.getStatus());
@@ -69,7 +71,7 @@ public class RestaurantControllerIntegrationTests extends AbstractIntegrationTes
     void restaurantControllerIntegration_CreateRestaurant_GivenNullRestaurantName_ReturnsBadRequest() throws Exception {
         restaurantDto.setName(null);
 
-        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(BRAND_API_ENDPOINT + "/" + savedBrand.getId(), restaurantDto, ExtendedProblemDetails.class);
+        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(url, restaurantDto, ExtendedProblemDetails.class);
 
         assertNotNull(problemDetail);
         assertEquals(HttpStatus.BAD_REQUEST.value(), problemDetail.getStatus());
@@ -82,7 +84,7 @@ public class RestaurantControllerIntegrationTests extends AbstractIntegrationTes
     void restaurantControllerIntegration_CreateRestaurant_GivenEmptyRestaurantAddress_ReturnsBadRequest() throws Exception {
         restaurantDto.setAddress("");
 
-        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(BRAND_API_ENDPOINT + "/" + savedBrand.getId(), restaurantDto, ExtendedProblemDetails.class);
+        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(url, restaurantDto, ExtendedProblemDetails.class);
 
         assertNotNull(problemDetail);
         assertEquals(HttpStatus.BAD_REQUEST.value(), problemDetail.getStatus());
@@ -95,7 +97,7 @@ public class RestaurantControllerIntegrationTests extends AbstractIntegrationTes
     void restaurantControllerIntegration_CreateRestaurant_GivenNullRestaurantAddress_ReturnsBadRequest() throws Exception {
         restaurantDto.setAddress(null);
 
-        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(BRAND_API_ENDPOINT + "/" + savedBrand.getId(), restaurantDto, ExtendedProblemDetails.class);
+        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(url, restaurantDto, ExtendedProblemDetails.class);
 
         assertNotNull(problemDetail);
         assertEquals(HttpStatus.BAD_REQUEST.value(), problemDetail.getStatus());
@@ -108,7 +110,7 @@ public class RestaurantControllerIntegrationTests extends AbstractIntegrationTes
     void restaurantControllerIntegration_CreateRestaurant_GivenNullRestaurantLongitude_ReturnsBadRequest() throws Exception {
         restaurantDto.setLongitude(null);
 
-        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(BRAND_API_ENDPOINT + "/" + savedBrand.getId(), restaurantDto, ExtendedProblemDetails.class);
+        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(url, restaurantDto, ExtendedProblemDetails.class);
 
         assertNotNull(problemDetail);
         assertEquals(HttpStatus.BAD_REQUEST.value(), problemDetail.getStatus());
@@ -121,7 +123,7 @@ public class RestaurantControllerIntegrationTests extends AbstractIntegrationTes
     void restaurantControllerIntegration_CreateRestaurant_GivenNullRestaurantLatitude_ReturnsBadRequest() throws Exception {
         restaurantDto.setLatitude(null);
 
-        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(BRAND_API_ENDPOINT + "/" + savedBrand.getId(), restaurantDto, ExtendedProblemDetails.class);
+        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(url, restaurantDto, ExtendedProblemDetails.class);
 
         assertNotNull(problemDetail);
         assertEquals(HttpStatus.BAD_REQUEST.value(), problemDetail.getStatus());
@@ -134,7 +136,7 @@ public class RestaurantControllerIntegrationTests extends AbstractIntegrationTes
     void restaurantControllerIntegration_CreateRestaurant_GivenRestaurantLongitudeGreaterThan180_ReturnsBadRequest() throws Exception {
         restaurantDto.setLongitude(181.0);
 
-        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(BRAND_API_ENDPOINT + "/" + savedBrand.getId(), restaurantDto, ExtendedProblemDetails.class);
+        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(url, restaurantDto, ExtendedProblemDetails.class);
 
         assertNotNull(problemDetail);
         assertEquals(HttpStatus.BAD_REQUEST.value(), problemDetail.getStatus());
@@ -147,7 +149,7 @@ public class RestaurantControllerIntegrationTests extends AbstractIntegrationTes
     void restaurantControllerIntegration_CreateRestaurant_GivenRestaurantLongitudeLessThanNegative180_ReturnsBadRequest() throws Exception {
         restaurantDto.setLongitude(-181.0);
 
-        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(BRAND_API_ENDPOINT + "/" + savedBrand.getId(), restaurantDto, ExtendedProblemDetails.class);
+        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(url, restaurantDto, ExtendedProblemDetails.class);
 
         assertNotNull(problemDetail);
         assertEquals(HttpStatus.BAD_REQUEST.value(), problemDetail.getStatus());
@@ -160,7 +162,7 @@ public class RestaurantControllerIntegrationTests extends AbstractIntegrationTes
     void restaurantControllerIntegration_CreateRestaurant_GivenRestaurantLatitudeGreaterThan90_ReturnsBadRequest() throws Exception {
         restaurantDto.setLatitude(91.0);
 
-        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(BRAND_API_ENDPOINT + "/" + savedBrand.getId(), restaurantDto, ExtendedProblemDetails.class);
+        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(url, restaurantDto, ExtendedProblemDetails.class);
 
         assertNotNull(problemDetail);
         assertEquals(HttpStatus.BAD_REQUEST.value(), problemDetail.getStatus());
@@ -173,7 +175,7 @@ public class RestaurantControllerIntegrationTests extends AbstractIntegrationTes
     void restaurantControllerIntegration_CreateRestaurant_GivenRestaurantLatitudeLessThanNegative90_ReturnsBadRequest() throws Exception {
         restaurantDto.setLatitude(-91.0);
 
-        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(BRAND_API_ENDPOINT + "/" + savedBrand.getId(), restaurantDto, ExtendedProblemDetails.class);
+        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(url, restaurantDto, ExtendedProblemDetails.class);
 
         assertNotNull(problemDetail);
         assertEquals(HttpStatus.BAD_REQUEST.value(), problemDetail.getStatus());
@@ -193,7 +195,7 @@ public class RestaurantControllerIntegrationTests extends AbstractIntegrationTes
 
         restaurantRepository.save(restaurant);
 
-        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(BRAND_API_ENDPOINT + "/" + savedBrand.getId(), restaurantDto, ExtendedProblemDetails.class);
+        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(url, restaurantDto, ExtendedProblemDetails.class);
 
         assertNotNull(problemDetail);
         assertEquals(HttpStatus.CONFLICT.value(), problemDetail.getStatus());
@@ -206,7 +208,9 @@ public class RestaurantControllerIntegrationTests extends AbstractIntegrationTes
         Long id = savedBrand.getId();
         brandRepository.delete(savedBrand);
 
-        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(BRAND_API_ENDPOINT + "/" + id, restaurantDto, ExtendedProblemDetails.class);
+        var invalidBrandUrl = BRAND_API_ENDPOINT + "/" + id + "/restaurant";
+
+        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(invalidBrandUrl, restaurantDto, ExtendedProblemDetails.class);
 
         assertNotNull(problemDetail);
         assertEquals(HttpStatus.NOT_FOUND.value(), problemDetail.getStatus());

--- a/src/test/java/org/qrush/brand/integration/RestaurantControllerIntegrationTests.java
+++ b/src/test/java/org/qrush/brand/integration/RestaurantControllerIntegrationTests.java
@@ -1,0 +1,217 @@
+package org.qrush.brand.integration;
+
+import jakarta.annotation.PostConstruct;
+import org.junit.jupiter.api.*;
+import org.qrush.brand.brand.BrandRepository;
+import org.qrush.brand.brand.models.Brand;
+import org.qrush.brand.integration.base.AbstractIntegrationTest;
+import org.qrush.brand.integration.base.ExtendedProblemDetails;
+import org.qrush.brand.restaurant.RestaurantRepository;
+import org.qrush.brand.restaurant.dto.RestaurantDto;
+import org.qrush.brand.restaurant.models.Restaurant;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.geo.Point;
+import org.springframework.http.HttpStatus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class RestaurantControllerIntegrationTests extends AbstractIntegrationTest {
+
+    @Autowired
+    private RestaurantRepository restaurantRepository;
+
+    @Autowired
+    private BrandRepository brandRepository;
+
+    private RestaurantDto restaurantDto;
+    private Brand brand;
+    private Brand savedBrand;
+
+    @PostConstruct
+    public void setup() {
+        restaurantDto = generateRestaurantDto();
+        brand = generateBrand();
+        savedBrand = brandRepository.save(brand);
+    }
+
+    // region POST
+    @Test
+    @DisplayName("Happy Path Test: create and return restaurant")
+    void restaurantControllerIntegration_CreateRestaurant_ReturnsRestaurantDto() throws Exception {
+
+        RestaurantDto createdRestaurant = performPostRequestExpectedSuccess(BRAND_API_ENDPOINT + "/" + savedBrand.getId().toString(), restaurantDto, RestaurantDto.class);
+
+        assertNotNull(createdRestaurant);
+        assertNotNull(createdRestaurant.getId());
+        assertEquals(restaurantDto.getName(), createdRestaurant.getName());
+        assertEquals(restaurantDto.getAddress(), createdRestaurant.getAddress());
+        assertEquals(restaurantDto.getLatitude(), createdRestaurant.getLatitude());
+        assertEquals(restaurantDto.getLongitude(), createdRestaurant.getLongitude());
+        assertEquals(savedBrand.getId(), createdRestaurant.getBrandId());
+    }
+
+    @Test
+    @DisplayName("Exception Test: restaurant name must not be empty")
+    void restaurantControllerIntegration_CreateRestaurant_GivenEmptyRestaurantName_ReturnsBadRequest() throws Exception {
+        restaurantDto.setName("");
+
+        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(BRAND_API_ENDPOINT + "/" + savedBrand.getId(), restaurantDto, ExtendedProblemDetails.class);
+
+        assertNotNull(problemDetail);
+        assertEquals(HttpStatus.BAD_REQUEST.value(), problemDetail.getStatus());
+        assertEquals("Invalid request parameters", problemDetail.getDetail());
+        assertEquals("Restaurant name cannot be null or empty", problemDetail.invalidParams.get("name"));
+    }
+
+    @Test
+    @DisplayName("Exception Test: restaurant name must not be null")
+    void restaurantControllerIntegration_CreateRestaurant_GivenNullRestaurantName_ReturnsBadRequest() throws Exception {
+        restaurantDto.setName(null);
+
+        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(BRAND_API_ENDPOINT + "/" + savedBrand.getId(), restaurantDto, ExtendedProblemDetails.class);
+
+        assertNotNull(problemDetail);
+        assertEquals(HttpStatus.BAD_REQUEST.value(), problemDetail.getStatus());
+        assertEquals("Invalid request parameters", problemDetail.getDetail());
+        assertEquals("Restaurant name cannot be null or empty", problemDetail.invalidParams.get("name"));
+    }
+
+    @Test
+    @DisplayName("Exception Test: restaurant address must not be empty")
+    void restaurantControllerIntegration_CreateRestaurant_GivenEmptyRestaurantAddress_ReturnsBadRequest() throws Exception {
+        restaurantDto.setAddress("");
+
+        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(BRAND_API_ENDPOINT + "/" + savedBrand.getId(), restaurantDto, ExtendedProblemDetails.class);
+
+        assertNotNull(problemDetail);
+        assertEquals(HttpStatus.BAD_REQUEST.value(), problemDetail.getStatus());
+        assertEquals("Invalid request parameters", problemDetail.getDetail());
+        assertEquals("Restaurant address cannot be null or empty", problemDetail.invalidParams.get("address"));
+    }
+
+    @Test
+    @DisplayName("Exception Test: restaurant address must not be null")
+    void restaurantControllerIntegration_CreateRestaurant_GivenNullRestaurantAddress_ReturnsBadRequest() throws Exception {
+        restaurantDto.setAddress(null);
+
+        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(BRAND_API_ENDPOINT + "/" + savedBrand.getId(), restaurantDto, ExtendedProblemDetails.class);
+
+        assertNotNull(problemDetail);
+        assertEquals(HttpStatus.BAD_REQUEST.value(), problemDetail.getStatus());
+        assertEquals("Invalid request parameters", problemDetail.getDetail());
+        assertEquals("Restaurant address cannot be null or empty", problemDetail.invalidParams.get("address"));
+    }
+
+    @Test
+    @DisplayName("Exception Test: restaurant longitude must not be null")
+    void restaurantControllerIntegration_CreateRestaurant_GivenNullRestaurantLongitude_ReturnsBadRequest() throws Exception {
+        restaurantDto.setLongitude(null);
+
+        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(BRAND_API_ENDPOINT + "/" + savedBrand.getId(), restaurantDto, ExtendedProblemDetails.class);
+
+        assertNotNull(problemDetail);
+        assertEquals(HttpStatus.BAD_REQUEST.value(), problemDetail.getStatus());
+        assertEquals("Invalid request parameters", problemDetail.getDetail());
+        assertEquals("Restaurant longitude cannot be null", problemDetail.invalidParams.get("longitude"));
+    }
+
+    @Test
+    @DisplayName("Exception Test: restaurant address must not be null")
+    void restaurantControllerIntegration_CreateRestaurant_GivenNullRestaurantLatitude_ReturnsBadRequest() throws Exception {
+        restaurantDto.setLatitude(null);
+
+        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(BRAND_API_ENDPOINT + "/" + savedBrand.getId(), restaurantDto, ExtendedProblemDetails.class);
+
+        assertNotNull(problemDetail);
+        assertEquals(HttpStatus.BAD_REQUEST.value(), problemDetail.getStatus());
+        assertEquals("Invalid request parameters", problemDetail.getDetail());
+        assertEquals("Restaurant latitude cannot be null", problemDetail.invalidParams.get("latitude"));
+    }
+
+    @Test
+    @DisplayName("Exception Test: restaurant longitude must be <= 180")
+    void restaurantControllerIntegration_CreateRestaurant_GivenRestaurantLongitudeGreaterThan180_ReturnsBadRequest() throws Exception {
+        restaurantDto.setLongitude(181.0);
+
+        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(BRAND_API_ENDPOINT + "/" + savedBrand.getId(), restaurantDto, ExtendedProblemDetails.class);
+
+        assertNotNull(problemDetail);
+        assertEquals(HttpStatus.BAD_REQUEST.value(), problemDetail.getStatus());
+        assertEquals("Invalid request parameters", problemDetail.getDetail());
+        assertEquals("Longitude must be between -180 and 180", problemDetail.invalidParams.get("longitude"));
+    }
+
+    @Test
+    @DisplayName("Exception Test: restaurant longitude must be => -180")
+    void restaurantControllerIntegration_CreateRestaurant_GivenRestaurantLongitudeLessThanNegative180_ReturnsBadRequest() throws Exception {
+        restaurantDto.setLongitude(-181.0);
+
+        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(BRAND_API_ENDPOINT + "/" + savedBrand.getId(), restaurantDto, ExtendedProblemDetails.class);
+
+        assertNotNull(problemDetail);
+        assertEquals(HttpStatus.BAD_REQUEST.value(), problemDetail.getStatus());
+        assertEquals("Invalid request parameters", problemDetail.getDetail());
+        assertEquals("Longitude must be between -180 and 180", problemDetail.invalidParams.get("longitude"));
+    }
+
+    @Test
+    @DisplayName("Exception Test: restaurant latitude must be <= 90")
+    void restaurantControllerIntegration_CreateRestaurant_GivenRestaurantLatitudeGreaterThan90_ReturnsBadRequest() throws Exception {
+        restaurantDto.setLatitude(91.0);
+
+        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(BRAND_API_ENDPOINT + "/" + savedBrand.getId(), restaurantDto, ExtendedProblemDetails.class);
+
+        assertNotNull(problemDetail);
+        assertEquals(HttpStatus.BAD_REQUEST.value(), problemDetail.getStatus());
+        assertEquals("Invalid request parameters", problemDetail.getDetail());
+        assertEquals("Latitude must be between -90 and 90", problemDetail.invalidParams.get("latitude"));
+    }
+
+    @Test
+    @DisplayName("Exception Test: restaurant latitude must be => -90")
+    void restaurantControllerIntegration_CreateRestaurant_GivenRestaurantLatitudeLessThanNegative90_ReturnsBadRequest() throws Exception {
+        restaurantDto.setLatitude(-91.0);
+
+        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(BRAND_API_ENDPOINT + "/" + savedBrand.getId(), restaurantDto, ExtendedProblemDetails.class);
+
+        assertNotNull(problemDetail);
+        assertEquals(HttpStatus.BAD_REQUEST.value(), problemDetail.getStatus());
+        assertEquals("Invalid request parameters", problemDetail.getDetail());
+        assertEquals("Latitude must be between -90 and 90", problemDetail.invalidParams.get("latitude"));
+    }
+
+    @Test
+    @DisplayName("Exception Test: restaurant name must be unique to brand")
+    void restaurantControllerIntegration_CreateRestaurant_GivenRestaurantNameAlreadyExistsForBrand_ReturnsConflict() throws Exception {
+        Restaurant restaurant = Restaurant.builder()
+                .name(restaurantDto.getName())
+                .address("456 Main Street")
+                .location(new Point(80, 80))
+                .brand(savedBrand)
+                .build();
+
+        restaurantRepository.save(restaurant);
+
+        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(BRAND_API_ENDPOINT + "/" + savedBrand.getId(), restaurantDto, ExtendedProblemDetails.class);
+
+        assertNotNull(problemDetail);
+        assertEquals(HttpStatus.CONFLICT.value(), problemDetail.getStatus());
+        assertEquals(String.format("Restaurant name already exists for brand %s", savedBrand.getName()), problemDetail.getDetail());
+    }
+
+    @Test
+    @DisplayName("Exception Test: brand must exist")
+    void restaurantControllerIntegration_CreateRestaurant_GivenBrandDoesNotExist_ReturnsNotFound() throws Exception {
+        Long id = savedBrand.getId();
+        brandRepository.delete(savedBrand);
+
+        ExtendedProblemDetails problemDetail = performPostRequestExpectClientError(BRAND_API_ENDPOINT + "/" + id, restaurantDto, ExtendedProblemDetails.class);
+
+        assertNotNull(problemDetail);
+        assertEquals(HttpStatus.NOT_FOUND.value(), problemDetail.getStatus());
+        assertEquals("Brand could not be found", problemDetail.getDetail());
+    }
+    //endregion
+}
+

--- a/src/test/java/org/qrush/brand/integration/base/ExtendedProblemDetails.java
+++ b/src/test/java/org/qrush/brand/integration/base/ExtendedProblemDetails.java
@@ -1,0 +1,12 @@
+package org.qrush.brand.integration.base;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.http.ProblemDetail;
+
+import java.util.Map;
+
+
+public class ExtendedProblemDetails extends ProblemDetail {
+    @JsonProperty("invalid-params")
+    public Map<String, String> invalidParams;
+}

--- a/src/test/java/org/qrush/brand/integration/base/TestFactory.java
+++ b/src/test/java/org/qrush/brand/integration/base/TestFactory.java
@@ -2,6 +2,7 @@ package org.qrush.brand.integration.base;
 
 import org.qrush.brand.brand.dto.BrandDto;
 import org.qrush.brand.brand.models.Brand;
+import org.qrush.brand.restaurant.dto.RestaurantDto;
 
 public class TestFactory {
     public static final String BRAND_API_ENDPOINT = "/brand";
@@ -15,6 +16,15 @@ public class TestFactory {
     public BrandDto generateBrandDto() {
         return BrandDto.builder()
                 .name("Starbucks")
+                .build();
+    }
+
+    public RestaurantDto generateRestaurantDto() {
+        return RestaurantDto.builder()
+                .name("Starbucks Ipswich")
+                .address("123 Main Street")
+                .latitude(90.0)
+                .longitude(180.0)
                 .build();
     }
 }

--- a/src/test/java/org/qrush/brand/unit/brand/BrandControllerTests.java
+++ b/src/test/java/org/qrush/brand/unit/brand/BrandControllerTests.java
@@ -89,7 +89,7 @@ class BrandControllerTests {
         response.andExpect(MockMvcResultMatchers.jsonPath("$.invalid-params.name").value("Brand name cannot be null or empty"));    }
 
     @Test
-    void brandController_CreateBrand_WhenBrandRepositoryFails_ReturnInternalServerError() throws Exception {
+    void brandController_CreateBrand_WhenBrandServiceFails_ReturnInternalServerError() throws Exception {
         when(brandService.createBrand(ArgumentMatchers.any())).thenThrow(ServiceException.class);
 
         ResultActions response = mockMvc.perform(post("/brand/create")
@@ -135,7 +135,7 @@ class BrandControllerTests {
     }
 
     @Test
-    void brandController_GetBrandById_WhenBrandRepositoryFails_ReturnsInternalServerError() throws Exception {
+    void brandController_GetBrandById_WhenBrandServiceFails_ReturnsInternalServerError() throws Exception {
         Long id = 1L;
         when(brandService.getBrandById(id)).thenThrow(ServiceException.class);
 
@@ -160,7 +160,7 @@ class BrandControllerTests {
     }
 
     @Test
-    void brandController_GetAllBrands_WhenBrandRepositoryFails_ReturnsInternalServerError() throws Exception {
+    void brandController_GetAllBrands_WhenBrandServiceFails_ReturnsInternalServerError() throws Exception {
         when(brandService.getAllBrands(0, 10)).thenThrow(ServiceException.class);
 
         ResultActions response = mockMvc.perform(get("/brand")
@@ -247,7 +247,7 @@ class BrandControllerTests {
         response.andExpect(MockMvcResultMatchers.jsonPath("$.invalid-params.name").value("Brand name cannot be null or empty"));    }
 
     @Test
-    void brandController_UpdateBrand_WhenBrandRepositoryFails_ReturnInternalServerError() throws Exception {
+    void brandController_UpdateBrand_WhenBrandServiceFails_ReturnInternalServerError() throws Exception {
         Long id = 1L;
         when(brandService.updateBrand(brandDto, id)).thenThrow(ServiceException.class);
 
@@ -281,7 +281,7 @@ class BrandControllerTests {
     }
 
     @Test
-    void brandController_DeleteBrandById_WhenBrandRepositoryFails_ReturnsInternalServerError() throws Exception {
+    void brandController_DeleteBrandById_WhenBrandServiceFails_ReturnsInternalServerError() throws Exception {
         Long id = 1L;
         doThrow(ServiceException.class).when(brandService).deleteBrand(id);
 

--- a/src/test/java/org/qrush/brand/unit/brand/BrandMapperTests.java
+++ b/src/test/java/org/qrush/brand/unit/brand/BrandMapperTests.java
@@ -1,0 +1,48 @@
+package org.qrush.brand.unit.brand;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.qrush.brand.brand.dto.BrandDto;
+import org.qrush.brand.brand.helpers.BrandMapper;
+import org.qrush.brand.brand.models.Brand;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class BrandMapperTests {
+
+    private BrandMapper brandMapper;
+    private Brand brand;
+    private BrandDto brandDto;
+
+    @BeforeEach
+    public void setup() {
+        brandMapper = new BrandMapper();
+
+        brand = Brand.builder()
+                .id(1L)
+                .name("Starbucks")
+                .build();
+
+        brandDto = BrandDto.builder()
+                .id(2l)
+                .name("Costa")
+                .build();
+
+    }
+
+    @Test
+    public void brandMapper_ToEntity_ReturnsBrandEntity() {
+        Brand brandMapperEntity = brandMapper.toEntity(brandDto);
+
+        assertEquals(brandDto.getId(), brandMapperEntity.getId());
+        assertEquals(brandDto.getName(), brandMapperEntity.getName());
+    }
+
+    @Test
+    public void brandMapper_ToDTO_ReturnsBrandDto() {
+        BrandDto brandMapperDTO = brandMapper.toDTO(brand);
+
+        assertEquals(brand.getId(), brandMapperDTO.getId());
+        assertEquals(brand.getName(), brandMapperDTO.getName());
+    }
+}

--- a/src/test/java/org/qrush/brand/unit/brand/BrandServiceTests.java
+++ b/src/test/java/org/qrush/brand/unit/brand/BrandServiceTests.java
@@ -47,6 +47,7 @@ class BrandServiceTests {
         BrandDto savedBrandDto = brandService.createBrand(brandDto);
 
         assertNotNull(savedBrandDto);
+        //ToDo: swap expected and equals
         assertEquals(savedBrandDto.getName(), brand.getName());
     }
 

--- a/src/test/java/org/qrush/brand/unit/restaurant/RestaurantControllerTests.java
+++ b/src/test/java/org/qrush/brand/unit/restaurant/RestaurantControllerTests.java
@@ -38,6 +38,7 @@ public class RestaurantControllerTests {
     private ObjectMapper objectMapper;
     private Brand brand;
     private RestaurantDto restaurantDto;
+    private String url;
 
     @BeforeEach
     public void setup() {
@@ -57,6 +58,7 @@ public class RestaurantControllerTests {
                 .build();
 
 
+        url = String.format("/brand/%s/restaurant", brand.getId());
     }
 
     //region CREATE
@@ -64,7 +66,7 @@ public class RestaurantControllerTests {
     void restaurantController_CreateRestaurant_ReturnsCreatedRestaurant() throws Exception {
         given(restaurantService.createRestaurant(ArgumentMatchers.any())).willAnswer((invocation -> invocation.getArgument(0)));
 
-        ResultActions response = mockMvc.perform(post(String.format("/brand/%s", brand.getId()))
+        ResultActions response = mockMvc.perform(post(url)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(restaurantDto)));
 
@@ -76,7 +78,7 @@ public class RestaurantControllerTests {
     void restaurantController_CreateRestaurant_GivenLongitudeOutsideRange_ReturnsBadRequest() throws Exception {
         restaurantDto.setLongitude(200.0);
 
-        ResultActions response = mockMvc.perform(post(String.format("/brand/%s", brand.getId()))
+        ResultActions response = mockMvc.perform(post(url)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(restaurantDto)));
 
@@ -89,7 +91,7 @@ public class RestaurantControllerTests {
     void restaurantController_CreateRestaurant_GivenLatitudeOutsideRange_ReturnsBadRequest() throws Exception {
         restaurantDto.setLatitude(200.0);
 
-        ResultActions response = mockMvc.perform(post(String.format("/brand/%s", brand.getId()))
+        ResultActions response = mockMvc.perform(post(url)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(restaurantDto)));
 
@@ -102,7 +104,7 @@ public class RestaurantControllerTests {
     void restaurantController_CreateRestaurant_GivenEmptyName_ReturnsBadRequest() throws Exception {
         restaurantDto.setName("");
 
-        ResultActions response = mockMvc.perform(post(String.format("/brand/%s", brand.getId()))
+        ResultActions response = mockMvc.perform(post(url)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(restaurantDto)));
 
@@ -115,7 +117,7 @@ public class RestaurantControllerTests {
     void restaurantController_CreateRestaurant_GivenEmptyAddress_ReturnsBadRequest() throws Exception {
         restaurantDto.setAddress("");
 
-        ResultActions response = mockMvc.perform(post(String.format("/brand/%s", brand.getId()))
+        ResultActions response = mockMvc.perform(post(url)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(restaurantDto)));
 
@@ -127,7 +129,7 @@ public class RestaurantControllerTests {
     @Test
     void restaurantController_CreateRestaurant_GivenInvalidJson_ReturnsBadRequest() throws Exception {
 
-        ResultActions response = mockMvc.perform(post(String.format("/brand/%s", brand.getId()))
+        ResultActions response = mockMvc.perform(post(url)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(Collections.singletonMap("request", "this doesn't match our schema"))));
 
@@ -142,7 +144,7 @@ public class RestaurantControllerTests {
     @Test
     void restaurantController_CreateRestaurant_GivenEmptyJson_ReturnsBadRequest() throws Exception {
 
-        ResultActions response = mockMvc.perform(post(String.format("/brand/%s", brand.getId()))
+        ResultActions response = mockMvc.perform(post(url)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(Collections.EMPTY_MAP)));
 
@@ -158,7 +160,7 @@ public class RestaurantControllerTests {
     void restaurantController_CreateRestaurant_RestaurantServiceFails_ReturnsInternalServerError() throws Exception {
         doThrow(ServiceException.class).when(restaurantService).createRestaurant(restaurantDto);
 
-        ResultActions response = mockMvc.perform(post(String.format("/brand/%s", brand.getId()))
+        ResultActions response = mockMvc.perform(post(url)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(restaurantDto)));
 

--- a/src/test/java/org/qrush/brand/unit/restaurant/RestaurantControllerTests.java
+++ b/src/test/java/org/qrush/brand/unit/restaurant/RestaurantControllerTests.java
@@ -1,0 +1,168 @@
+package org.qrush.brand.unit.restaurant;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hibernate.service.spi.ServiceException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.qrush.brand.brand.models.Brand;
+import org.qrush.brand.restaurant.RestaurantController;
+import org.qrush.brand.restaurant.RestaurantService;
+import org.qrush.brand.restaurant.dto.RestaurantDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.util.Collections;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+@WebMvcTest(controllers = RestaurantController.class)
+@ExtendWith(MockitoExtension.class)
+public class RestaurantControllerTests {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RestaurantService restaurantService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+    private Brand brand;
+    private RestaurantDto restaurantDto;
+
+    @BeforeEach
+    public void setup() {
+        brand = Brand.builder()
+                .id(1L)
+                .name("Starbucks")
+                .build();
+
+
+
+        restaurantDto = RestaurantDto.builder()
+                .name("Starbucks Ipswich")
+                .address("123 Main Street")
+                .latitude(90.0)
+                .longitude(180.0)
+                .brandId(brand.getId())
+                .build();
+
+
+    }
+
+    //region CREATE
+    @Test
+    void restaurantController_CreateRestaurant_ReturnsCreatedRestaurant() throws Exception {
+        given(restaurantService.createRestaurant(ArgumentMatchers.any())).willAnswer((invocation -> invocation.getArgument(0)));
+
+        ResultActions response = mockMvc.perform(post(String.format("/brand/%s", brand.getId()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(restaurantDto)));
+
+        response.andExpect(MockMvcResultMatchers.status().isCreated());
+        response.andExpect(MockMvcResultMatchers.content().json(objectMapper.writeValueAsString(restaurantDto)));
+    }
+
+    @Test
+    void restaurantController_CreateRestaurant_GivenLongitudeOutsideRange_ReturnsBadRequest() throws Exception {
+        restaurantDto.setLongitude(200.0);
+
+        ResultActions response = mockMvc.perform(post(String.format("/brand/%s", brand.getId()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(restaurantDto)));
+
+        response.andExpect(MockMvcResultMatchers.status().isBadRequest());
+        response.andExpect(MockMvcResultMatchers.jsonPath("$.detail").value("Invalid request parameters"));
+        response.andExpect(MockMvcResultMatchers.jsonPath("$.invalid-params.longitude").value("Longitude must be between -180 and 180"));
+    }
+
+    @Test
+    void restaurantController_CreateRestaurant_GivenLatitudeOutsideRange_ReturnsBadRequest() throws Exception {
+        restaurantDto.setLatitude(200.0);
+
+        ResultActions response = mockMvc.perform(post(String.format("/brand/%s", brand.getId()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(restaurantDto)));
+
+        response.andExpect(MockMvcResultMatchers.status().isBadRequest());
+        response.andExpect(MockMvcResultMatchers.jsonPath("$.detail").value("Invalid request parameters"));
+        response.andExpect(MockMvcResultMatchers.jsonPath("$.invalid-params.latitude").value("Latitude must be between -90 and 90"));
+    }
+
+    @Test
+    void restaurantController_CreateRestaurant_GivenEmptyName_ReturnsBadRequest() throws Exception {
+        restaurantDto.setName("");
+
+        ResultActions response = mockMvc.perform(post(String.format("/brand/%s", brand.getId()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(restaurantDto)));
+
+        response.andExpect(MockMvcResultMatchers.status().isBadRequest());
+        response.andExpect(MockMvcResultMatchers.jsonPath("$.detail").value("Invalid request parameters"));
+        response.andExpect(MockMvcResultMatchers.jsonPath("$.invalid-params.name").value("Restaurant name cannot be null or empty"));
+    }
+
+    @Test
+    void restaurantController_CreateRestaurant_GivenEmptyAddress_ReturnsBadRequest() throws Exception {
+        restaurantDto.setAddress("");
+
+        ResultActions response = mockMvc.perform(post(String.format("/brand/%s", brand.getId()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(restaurantDto)));
+
+        response.andExpect(MockMvcResultMatchers.status().isBadRequest());
+        response.andExpect(MockMvcResultMatchers.jsonPath("$.detail").value("Invalid request parameters"));
+        response.andExpect(MockMvcResultMatchers.jsonPath("$.invalid-params.address").value("Restaurant address cannot be null or empty"));
+    }
+
+    @Test
+    void restaurantController_CreateRestaurant_GivenInvalidJson_ReturnsBadRequest() throws Exception {
+
+        ResultActions response = mockMvc.perform(post(String.format("/brand/%s", brand.getId()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Collections.singletonMap("request", "this doesn't match our schema"))));
+
+        response.andExpect(MockMvcResultMatchers.status().isBadRequest());
+        response.andExpect(MockMvcResultMatchers.jsonPath("$.detail").value("Invalid request parameters"));
+        response.andExpect(MockMvcResultMatchers.jsonPath("$.invalid-params.address").value("Restaurant address cannot be null or empty"));
+        response.andExpect(MockMvcResultMatchers.jsonPath("$.invalid-params.address").value("Restaurant address cannot be null or empty"));
+        response.andExpect(MockMvcResultMatchers.jsonPath("$.invalid-params.longitude").value("Restaurant longitude cannot be null"));
+        response.andExpect(MockMvcResultMatchers.jsonPath("$.invalid-params.latitude").value("Restaurant latitude cannot be null"));
+    }
+
+    @Test
+    void restaurantController_CreateRestaurant_GivenEmptyJson_ReturnsBadRequest() throws Exception {
+
+        ResultActions response = mockMvc.perform(post(String.format("/brand/%s", brand.getId()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Collections.EMPTY_MAP)));
+
+        response.andExpect(MockMvcResultMatchers.status().isBadRequest());
+        response.andExpect(MockMvcResultMatchers.jsonPath("$.detail").value("Invalid request parameters"));
+        response.andExpect(MockMvcResultMatchers.jsonPath("$.invalid-params.address").value("Restaurant address cannot be null or empty"));
+        response.andExpect(MockMvcResultMatchers.jsonPath("$.invalid-params.address").value("Restaurant address cannot be null or empty"));
+        response.andExpect(MockMvcResultMatchers.jsonPath("$.invalid-params.longitude").value("Restaurant longitude cannot be null"));
+        response.andExpect(MockMvcResultMatchers.jsonPath("$.invalid-params.latitude").value("Restaurant latitude cannot be null"));
+    }
+
+    @Test
+    void restaurantController_CreateRestaurant_RestaurantServiceFails_ReturnsInternalServerError() throws Exception {
+        doThrow(ServiceException.class).when(restaurantService).createRestaurant(restaurantDto);
+
+        ResultActions response = mockMvc.perform(post(String.format("/brand/%s", brand.getId()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(restaurantDto)));
+
+        response.andExpect(MockMvcResultMatchers.status().isInternalServerError());
+    }
+    // endregion
+}

--- a/src/test/java/org/qrush/brand/unit/restaurant/RestaurantMapperTests.java
+++ b/src/test/java/org/qrush/brand/unit/restaurant/RestaurantMapperTests.java
@@ -1,0 +1,68 @@
+package org.qrush.brand.unit.restaurant;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.qrush.brand.brand.models.Brand;
+import org.qrush.brand.restaurant.dto.RestaurantDto;
+import org.qrush.brand.restaurant.helpers.RestaurantMapper;
+import org.qrush.brand.restaurant.models.Restaurant;
+import org.springframework.data.geo.Point;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RestaurantMapperTests {
+
+    private RestaurantMapper restaurantMapper;
+    private RestaurantDto restaurantDto;
+    private Restaurant restaurant;
+    private Brand brand;
+
+    @BeforeEach
+    public void setup() {
+        restaurantMapper = new RestaurantMapper();
+
+        brand = Brand.builder()
+                .id(1L)
+                .name("Starbucks")
+                .build();
+
+        restaurantDto = RestaurantDto.builder()
+                .id(null)
+                .name("Starbucks Ipswich")
+                .brandId(1L)
+                .address("123 Street")
+                .latitude(1.0)
+                .longitude(50.0)
+                .build();
+
+        restaurant = Restaurant.builder()
+                .name("Starbucks Ipswich")
+                .brand(brand)
+                .address("123 Street")
+                .location(new Point(1.0, 50.0))
+                .build();
+    }
+
+    @Test
+    public void restaurantMapper_ToEntity_ReturnsRestaurantEntity() {
+        Restaurant restaurantEntity = restaurantMapper.toEntity(restaurantDto, brand);
+
+        assertEquals(restaurantDto.getName(), restaurantEntity.getName());
+        assertEquals(brand, restaurantEntity.getBrand());
+        assertEquals(restaurantDto.getAddress(), restaurantEntity.getAddress());
+        assertEquals(restaurantDto.getLatitude(), restaurantEntity.getLocation().getY());
+        assertEquals(restaurantDto.getLongitude(), restaurantEntity.getLocation().getX());
+    }
+
+    @Test
+    public void restaurantMapper_ToDTO_ReturnsRestaurantDto() {
+        RestaurantDto restaurantDto = restaurantMapper.toDTO(restaurant);
+
+        assertEquals(restaurant.getId(), restaurantDto.getId());
+        assertEquals(restaurant.getName(), restaurantDto.getName());
+        assertEquals(restaurant.getBrand().getId(), restaurantDto.getBrandId());
+        assertEquals(restaurant.getAddress(), restaurantDto.getAddress());
+        assertEquals(restaurant.getLocation().getY(), restaurantDto.getLatitude());
+        assertEquals(restaurant.getLocation().getX(), restaurantDto.getLongitude());
+    }
+}

--- a/src/test/java/org/qrush/brand/unit/restaurant/RestaurantRepositoryTests.java
+++ b/src/test/java/org/qrush/brand/unit/restaurant/RestaurantRepositoryTests.java
@@ -1,0 +1,163 @@
+package org.qrush.brand.unit.restaurant;
+
+import jakarta.transaction.Transactional;
+import jakarta.validation.ConstraintViolationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.qrush.brand.brand.BrandRepository;
+import org.qrush.brand.brand.models.Brand;
+import org.qrush.brand.restaurant.RestaurantRepository;
+import org.qrush.brand.restaurant.models.Restaurant;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.geo.Point;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
+@Transactional
+public class RestaurantRepositoryTests {
+
+    @Autowired
+    private RestaurantRepository restaurantRepository;
+
+    @Autowired
+    private BrandRepository brandRepository;
+
+    private Restaurant restaurant;
+    private Brand brand;
+
+    @BeforeEach
+    public void setup() {
+        brand = Brand.builder()
+                .name("Starbucks")
+                .id(1L)
+                .build();
+
+        restaurant = Restaurant.builder()
+                .name("Starbucks Ipswich")
+                .address("123 Street")
+                .location(new Point(80.0, 80.0))
+                .brand(brand)
+                .build();
+
+    }
+
+    @Test
+    public void restaurantRepository_Save_ReturnsSavedRestaurant() {
+        Restaurant savedRestaurant = restaurantRepository.save(restaurant);
+
+        assertNotNull(savedRestaurant);
+        assertNotNull(savedRestaurant.getId());
+        assertEquals(restaurant.getName(), savedRestaurant.getName());
+        assertEquals(restaurant.getAddress(), savedRestaurant.getAddress());
+        assertEquals(restaurant.getLocation(), savedRestaurant.getLocation());
+        assertEquals(restaurant.getBrand(), savedRestaurant.getBrand());
+    }
+
+    @Test
+    public void restaurantRepository_Save_GivenEmptyRestaurantName_ThrowsConstraintViolationException() {
+        restaurant.setName("");
+
+        var constraintViolationException  = assertThrows(ConstraintViolationException.class, () -> restaurantRepository.saveAndFlush(restaurant));
+        var exceptionMessage = constraintViolationException.getConstraintViolations().stream().findFirst().get().getMessage();
+
+        assertEquals(exceptionMessage, "Restaurant name cannot be null or empty");
+    }
+
+    @Test
+    public void restaurantRepository_Save_GivenNullRestaurantName_ThrowsConstraintViolationException() {
+        restaurant.setName(null);
+
+        var constraintViolationException  = assertThrows(ConstraintViolationException.class, () -> restaurantRepository.saveAndFlush(restaurant));
+        var exceptionMessage = constraintViolationException.getConstraintViolations().stream().findFirst().get().getMessage();
+
+        assertEquals(exceptionMessage, "Restaurant name cannot be null or empty");
+    }
+
+    @Test
+    public void restaurantRepository_Save_GivenEmptyRestaurantAddress_ThrowsConstraintViolationException() {
+        restaurant.setAddress("");
+
+        var constraintViolationException  = assertThrows(ConstraintViolationException.class, () -> restaurantRepository.saveAndFlush(restaurant));
+        var exceptionMessage = constraintViolationException.getConstraintViolations().stream().findFirst().get().getMessage();
+
+        assertEquals(exceptionMessage, "Restaurant address cannot be null or empty");
+    }
+
+    @Test
+    public void restaurantRepository_Save_GivenNullRestaurantAddress_ThrowsConstraintViolationException() {
+        restaurant.setAddress(null);
+
+        var constraintViolationException  = assertThrows(ConstraintViolationException.class, () -> restaurantRepository.saveAndFlush(restaurant));
+        var exceptionMessage = constraintViolationException.getConstraintViolations().stream().findFirst().get().getMessage();
+
+        assertEquals(exceptionMessage, "Restaurant address cannot be null or empty");
+    }
+
+    @Test
+    public void restaurantRepository_Save_GivenNullRestaurantLocation_ThrowsConstraintViolationException() {
+        restaurant.setLocation(null);
+
+        var constraintViolationException  = assertThrows(ConstraintViolationException.class, () -> restaurantRepository.saveAndFlush(restaurant));
+        var exceptionMessage = constraintViolationException.getConstraintViolations().stream().findFirst().get().getMessage();
+
+        assertEquals(exceptionMessage, "Restaurant location cannot be null");
+    }
+
+    @Test
+    public void restaurantRepository_Save_GivenRestaurantNameAlreadyExistsForBrand_ThrowsDataIntegrityException() {
+        Brand savedBrand = brandRepository.save(brand);
+        restaurant.setBrand(savedBrand);
+
+        restaurantRepository.save(restaurant);
+        Restaurant duplicateRestaurant = Restaurant.builder()
+                .name(restaurant.getName())
+                .address(restaurant.getAddress())
+                .location(restaurant.getLocation())
+                .brand(restaurant.getBrand())
+                .build();
+
+       var dataIntegrityViolationException =  assertThrows(DataIntegrityViolationException.class, () -> restaurantRepository.saveAndFlush(duplicateRestaurant));
+       var localizedMessage = dataIntegrityViolationException.getCause().getLocalizedMessage();
+
+       assertTrue(localizedMessage.contains("Unique restaurant name for each brand"), "Data integrity violation on unique constraint unique restaurant name per brand");
+    }
+
+    @Test
+    public void restaurantRepository_FindByNameAndBrandId_ReturnsRestaurant() {
+        Brand savedBrand = brandRepository.save(brand);
+
+        restaurant.setBrand(savedBrand);
+        restaurantRepository.save(restaurant);
+
+        Restaurant foundRestaurant = restaurantRepository.findByNameAndBrandId(restaurant.getName(), restaurant.getBrand().getId()).orElse(null);
+
+        assertNotNull(foundRestaurant);
+        assertNotNull(foundRestaurant.getId());
+        assertEquals(restaurant.getName(), foundRestaurant.getName());
+        assertEquals(restaurant.getAddress(), foundRestaurant.getAddress());
+        assertEquals(restaurant.getLocation(), foundRestaurant.getLocation());
+        assertEquals(restaurant.getBrand(), foundRestaurant.getBrand());
+    }
+
+    @Test
+    public void restaurantRepository_FindByNameAndBrandId_GivenRestaurantNameDoesntExist_ReturnsNull() {
+        brandRepository.save(brand);
+        Restaurant foundRestaurant = restaurantRepository.findByNameAndBrandId(restaurant.getName(), restaurant.getBrand().getId()).orElse(null);
+
+        assertNull(foundRestaurant);
+    }
+
+    @Test
+    public void restaurantRepository_FindByNameAndBrandId_GivenBrandDoesntExist_ReturnsNull() {
+        Restaurant foundRestaurant = restaurantRepository.findByNameAndBrandId(restaurant.getName(), restaurant.getBrand().getId()).orElse(null);
+
+        assertNull(foundRestaurant);
+    }
+}
+

--- a/src/test/java/org/qrush/brand/unit/restaurant/RestaurantServiceTests.java
+++ b/src/test/java/org/qrush/brand/unit/restaurant/RestaurantServiceTests.java
@@ -1,0 +1,109 @@
+package org.qrush.brand.unit.restaurant;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.qrush.brand.brand.BrandService;
+import org.qrush.brand.brand.dto.BrandDto;
+import org.qrush.brand.brand.exceptions.BrandNotFoundException;
+import org.qrush.brand.brand.helpers.BrandMapper;
+import org.qrush.brand.restaurant.RestaurantRepository;
+import org.qrush.brand.restaurant.RestaurantService;
+import org.qrush.brand.restaurant.dto.RestaurantDto;
+import org.qrush.brand.brand.models.Brand;
+import org.qrush.brand.restaurant.exceptions.RestaurantAlreadyExists;
+import org.qrush.brand.restaurant.helpers.RestaurantMapper;
+import org.qrush.brand.restaurant.models.Restaurant;
+import org.springframework.data.geo.Point;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class RestaurantServiceTests {
+
+    @Mock
+    private RestaurantRepository restaurantRepository;
+
+    @Mock
+    private BrandService brandService;
+
+    @Spy
+    private RestaurantMapper restaurantMapper;
+
+    @Spy
+    private BrandMapper brandMapper;
+
+    @InjectMocks
+    private RestaurantService restaurantService;
+
+    private Long brandId;
+    private BrandDto brandDto;
+    private Brand brand;
+    private RestaurantDto restaurantDto;
+    private Restaurant restaurant;
+
+    @BeforeEach
+    public void setup() {
+        brandId = 1L;
+        brand = Brand.builder()
+                .id(brandId)
+                .name("Starbucks")
+                .build();
+        brandDto = BrandDto.builder()
+                .name(brand.getName())
+                .id(brand.getId())
+                .build();
+
+        restaurantDto = RestaurantDto.builder()
+                .name("Starbucks London")
+                .address("123 Main St")
+                .longitude(90.0)
+                .latitude(180.0)
+                .brandId(brandId)
+                .build();
+
+        restaurant = Restaurant.builder()
+                .name(restaurantDto.getName())
+                .address(restaurantDto.getAddress())
+                .location(new Point(restaurantDto.getLongitude(), restaurantDto.getLatitude()))
+                .brand(brand)
+                .build();
+    }
+
+    //region CREATE
+    @Test
+    public void restaurantService_CreateRestaurant_ReturnsRestaurantDto() {
+        when(brandService.getBrandById(Mockito.anyLong())).thenReturn(brandDto);
+        when(restaurantRepository.save(Mockito.any(Restaurant.class))).thenReturn(restaurant);
+
+        RestaurantDto savedRestaurantDto = restaurantService.createRestaurant(restaurantDto);
+
+        assertNotNull(savedRestaurantDto);
+        assertEquals(restaurantDto.getName(), savedRestaurantDto.getName());
+        assertEquals(restaurantDto.getAddress(), savedRestaurantDto.getAddress());
+        assertEquals(restaurantDto.getBrandId(), savedRestaurantDto.getBrandId());
+        assertEquals(restaurantDto.getLatitude(), savedRestaurantDto.getLatitude());
+        assertEquals(restaurantDto.getLongitude(), savedRestaurantDto.getLongitude());
+    }
+
+    @Test
+    public void restaurantService_CreateRestaurant_GivenBrandDoesNotExist_ThrowsNotFoundException() {
+        when(brandService.getBrandById(Mockito.anyLong())).thenThrow(BrandNotFoundException.class);
+
+        assertThrows(BrandNotFoundException.class, () -> restaurantService.createRestaurant(restaurantDto));
+    }
+
+    @Test
+    public void restaurantService_CreateBrand_GivenRestaurantNameAlreadyExistsForBrand_ThrowsRestaurantAlreadyExists() {
+        when(brandService.getBrandById(Mockito.anyLong())).thenReturn(brandDto);
+        when(restaurantRepository.findByNameAndBrandId(Mockito.anyString(), Mockito.anyLong())).thenReturn(Optional.of(restaurant));
+
+        assertThrows(RestaurantAlreadyExists.class, () -> restaurantService.createRestaurant(restaurantDto));
+    }
+    //endregion
+}


### PR DESCRIPTION
**General**
Enable users to add restaurants to a brand. Checks to ensure brand exists and that restaurant name for that brand doesn't already exist in database. 

Requests are currently not idempotent - you will generate an error sending the same request twice as restaurant name will exist for that brand after first successful request.

Restaurant creation requires a valid location which must be within accepted range for latitude and longitude (-90 to 90 and -180 to 180 respectively).

Request route: api/brand/{brand_id}/restaurant

[CPG-41: Enable Restaurant Creation](https://qrush.atlassian.net/browse/CPG-41)

**Testing**
New endpoint is covered by unit and integration tests, focusing on 5 expected responses:

- successful creation of restaurant
- brand not found exception
- restaurant name already exists exception
- invalid request body
- internal server error


**SAT**
I spun up the service locally in docker, created a new brand with name "Starbucks" and id = 1 then sent the following update request to the Restaurant service:

Post Restaurant Request
POST /v1/brand/1/restaurant

{
  "name": "Starbucks Stevenage",
  "address": "Stevenage",
  "latitude": 90,
  "longitude": 180
}

Response
Status: 201 Created
Body

{
    "id": "3503b3d8-7fd2-40cc-9baf-644ead7a7811",
    "name": "Starbucks Stevenage",
    "address": "Stevenage",
    "latitude": 90.0,
    "longitude": 180.0,
    "brandId": 1
}