### PR TITLE
Remove /create from Brand POST route

### DIFF
--- a/src/main/java/org/qrush/brand/brand/BrandController.java
+++ b/src/main/java/org/qrush/brand/brand/BrandController.java
@@ -35,7 +35,7 @@ public class BrandController {
         return ResponseEntity.ok(brandService.getAllBrands(pageNo, pageSize));
     }
 
-    @PostMapping("/create")
+    @PostMapping()
     public ResponseEntity<BrandDto> createBrand(@RequestBody @Valid BrandDto brandDto) {
         return new ResponseEntity<>(brandService.createBrand(brandDto), HttpStatus.CREATED);
     }

--- a/src/test/java/org/qrush/brand/integration/BrandControllerIntegrationTests.java
+++ b/src/test/java/org/qrush/brand/integration/BrandControllerIntegrationTests.java
@@ -39,7 +39,7 @@ public class BrandControllerIntegrationTests extends AbstractIntegrationTest {
     @DisplayName("Happy Path Test: create and return brand")
     void brandControllerIntegration_CreateBrand_ReturnsBrandDto() throws Exception {
 
-        BrandDto createdBrand = performPostRequestExpectedSuccess(BRAND_API_ENDPOINT + "/create", brandDto, BrandDto.class);
+        BrandDto createdBrand = performPostRequestExpectedSuccess(BRAND_API_ENDPOINT, brandDto, BrandDto.class);
 
         assertNotNull(createdBrand);
         assertEquals("Starbucks", createdBrand.getName());
@@ -51,7 +51,7 @@ public class BrandControllerIntegrationTests extends AbstractIntegrationTest {
     void brandControllerIntegration_CreateBrand_GivenNullBrandName_ReturnsBadRequest() throws Exception {
         brandDto.setName(null);
 
-        ProblemDetail problemDetail = performPostRequestExpectClientError(BRAND_API_ENDPOINT + "/create", brandDto, ProblemDetail.class);
+        ProblemDetail problemDetail = performPostRequestExpectClientError(BRAND_API_ENDPOINT, brandDto, ProblemDetail.class);
 
         assertNotNull(problemDetail);
         assertEquals(HttpStatus.BAD_REQUEST.value(), problemDetail.getStatus());
@@ -63,7 +63,7 @@ public class BrandControllerIntegrationTests extends AbstractIntegrationTest {
     void brandControllerIntegration_CreateBrand_GivenEmptyBrandName_ReturnsBadRequest() throws Exception {
         brandDto.setName("");
 
-        ProblemDetail problemDetail = performPostRequestExpectClientError(BRAND_API_ENDPOINT + "/create", brandDto, ProblemDetail.class);
+        ProblemDetail problemDetail = performPostRequestExpectClientError(BRAND_API_ENDPOINT, brandDto, ProblemDetail.class);
 
         assertNotNull(problemDetail);
         assertEquals(HttpStatus.BAD_REQUEST.value(), problemDetail.getStatus());
@@ -76,7 +76,7 @@ public class BrandControllerIntegrationTests extends AbstractIntegrationTest {
         Brand brand = generateBrand();
         brandRepository.save(brand);
 
-        ProblemDetail problemDetail = performPostRequestExpectClientError(BRAND_API_ENDPOINT + "/create", brandDto, ProblemDetail.class);
+        ProblemDetail problemDetail = performPostRequestExpectClientError(BRAND_API_ENDPOINT, brandDto, ProblemDetail.class);
 
         assertNotNull(problemDetail);
         assertEquals(HttpStatus.CONFLICT.value(), problemDetail.getStatus());

--- a/src/test/java/org/qrush/brand/unit/brand/BrandControllerTests.java
+++ b/src/test/java/org/qrush/brand/unit/brand/BrandControllerTests.java
@@ -57,7 +57,7 @@ class BrandControllerTests {
     void brandController_CreateBrand_ReturnsCreatedBrand() throws Exception {
         given(brandService.createBrand(ArgumentMatchers.any())).willAnswer((invocation -> invocation.getArgument(0)));
 
-        ResultActions response = mockMvc.perform(post("/brand/create")
+        ResultActions response = mockMvc.perform(post("/brand")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(brandDto)));
 
@@ -68,7 +68,7 @@ class BrandControllerTests {
     @Test
     void brandController_CreateBrand_GivenEmptyJSON_ReturnsBadRequest() throws Exception {
 
-        ResultActions response = mockMvc.perform(post("/brand/create")
+        ResultActions response = mockMvc.perform(post("/brand")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(Collections.EMPTY_MAP)));
 
@@ -80,7 +80,7 @@ class BrandControllerTests {
     @Test
     void brandController_CreateBrand_GivenInvalidJSON_ReturnsBadRequest() throws Exception {
 
-        ResultActions response = mockMvc.perform(post("/brand/create")
+        ResultActions response = mockMvc.perform(post("/brand")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(Collections.singletonMap("request", "this doesn't match our schema"))));
 
@@ -92,7 +92,7 @@ class BrandControllerTests {
     void brandController_CreateBrand_WhenBrandRepositoryFails_ReturnInternalServerError() throws Exception {
         when(brandService.createBrand(ArgumentMatchers.any())).thenThrow(ServiceException.class);
 
-        ResultActions response = mockMvc.perform(post("/brand/create")
+        ResultActions response = mockMvc.perform(post("/brand")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(brandDto)));
 
@@ -103,7 +103,7 @@ class BrandControllerTests {
     void brandController_CreateBrand_WhenBrandAlreadyExists_ReturnsConflict() throws Exception {
         when(brandService.createBrand(ArgumentMatchers.any())).thenThrow(BrandAlreadyExists.class);
 
-        ResultActions response = mockMvc.perform(post("/brand/create")
+        ResultActions response = mockMvc.perform(post("/brand")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(brandDto)));
 


### PR DESCRIPTION
### General
Remove the "/create" suffix from Brand POST route for creating new Brands.

[CPG-42: Remove /create from Brand POST route](https://qrush.atlassian.net/browse/CPG-42)

### Testing
Covered by unit and integration tests

### SAT
I spun up the service locally in docker, created a new brand with name "Costa" :

Post Brands Request
POST /v1/brand/

{
  "name": "Costa"
}
Response
Status: 201 Created
Body

{
  "id": "1",
  "name": "Costa"
}