### PR TITLE
Switch Brand Id form Long to GUID

### DIFF
--- a/src/main/java/org/qrush/brand/brand/BrandController.java
+++ b/src/main/java/org/qrush/brand/brand/BrandController.java
@@ -7,6 +7,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.UUID;
+
 @RestController
 @RequestMapping("/brand")
 public class BrandController {
@@ -18,7 +20,7 @@ public class BrandController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<BrandDto> getBrand(@PathVariable Long id) {
+    public ResponseEntity<BrandDto> getBrand(@PathVariable UUID id) {
         return ResponseEntity.ok(brandService.getBrandById(id));
     }
 
@@ -41,12 +43,12 @@ public class BrandController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<BrandDto> updateBrand(@PathVariable Long id, @RequestBody @Valid BrandDto brandDto) {
+    public ResponseEntity<BrandDto> updateBrand(@PathVariable UUID id, @RequestBody @Valid BrandDto brandDto) {
         return new ResponseEntity<>(brandService.updateBrand(brandDto,id), HttpStatus.OK);
     }
 
     @DeleteMapping("/{id}/delete")
-    public ResponseEntity<Object> deleteBrand(@PathVariable Long id) {
+    public ResponseEntity<Object> deleteBrand(@PathVariable UUID id) {
         brandService.deleteBrand(id);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/org/qrush/brand/brand/BrandRepository.java
+++ b/src/main/java/org/qrush/brand/brand/BrandRepository.java
@@ -4,8 +4,9 @@ import org.qrush.brand.brand.models.Brand;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import java.util.UUID;
 
-public interface BrandRepository extends JpaRepository<Brand, Long> {
+public interface BrandRepository extends JpaRepository<Brand, UUID> {
     Optional<Brand> findByName(String name);
 }
 

--- a/src/main/java/org/qrush/brand/brand/BrandService.java
+++ b/src/main/java/org/qrush/brand/brand/BrandService.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 public class BrandService {
@@ -21,7 +22,7 @@ public class BrandService {
         this.brandRepository = brandRepository;
     }
 
-    public BrandDto getBrandById(Long id) {
+    public BrandDto getBrandById(UUID id) {
        Brand brand = brandRepository.findById(id).orElseThrow(() -> new BrandNotFoundException("Brand could not be found"));
        return mapToDto(brand);
     }
@@ -59,7 +60,7 @@ public class BrandService {
         return brandResponse;
     }
 
-    public BrandDto updateBrand(BrandDto brandDto, Long id) {
+    public BrandDto updateBrand(BrandDto brandDto, UUID id) {
         Brand brand = brandRepository.findById(id).orElseThrow(() -> new BrandNotFoundException("Brand not found"));
 
         if (checkBrandNameExists(brandDto)) {
@@ -72,7 +73,7 @@ public class BrandService {
         return mapToDto(updatedBrand);
     }
 
-    public void deleteBrand(Long id) {
+    public void deleteBrand(UUID id) {
        Brand brand = brandRepository.findById(id).orElseThrow(() -> new BrandNotFoundException("Brand not found"));
        brandRepository.delete(brand);
     }

--- a/src/main/java/org/qrush/brand/brand/dto/BrandDto.java
+++ b/src/main/java/org/qrush/brand/brand/dto/BrandDto.java
@@ -7,13 +7,15 @@ import lombok.NoArgsConstructor;
 
 import jakarta.validation.constraints.NotEmpty;
 
+import java.util.UUID;
+
 @Data
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class BrandDto {
 
-    private Long id;
+    private UUID id;
 
     @NotEmpty(message = "Brand name cannot be null or empty")
     private String name;

--- a/src/main/java/org/qrush/brand/brand/models/Brand.java
+++ b/src/main/java/org/qrush/brand/brand/models/Brand.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.UUID;
 
 
 @Data
@@ -17,8 +18,8 @@ import lombok.NoArgsConstructor;
 public class Brand {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
 
     @Column(unique= true)
     @NotEmpty(message = "Brand name cannot be null or empty")

--- a/src/main/java/org/qrush/brand/restaurant/RestaurantController.java
+++ b/src/main/java/org/qrush/brand/restaurant/RestaurantController.java
@@ -6,6 +6,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.UUID;
+
 @RestController
 @RequestMapping("/brand/{brand_id}/restaurant")
 public class RestaurantController {
@@ -16,7 +18,7 @@ public class RestaurantController {
     }
 
     @PostMapping()
-    public ResponseEntity<RestaurantDto> createRestaurant(@PathVariable("brand_id") Long brandId, @RequestBody @Valid RestaurantDto restaurantDto) {
+    public ResponseEntity<RestaurantDto> createRestaurant(@PathVariable("brand_id") UUID brandId, @RequestBody @Valid RestaurantDto restaurantDto) {
         restaurantDto.setBrandId(brandId);
         return new ResponseEntity<>(restaurantService.createRestaurant(restaurantDto), HttpStatus.CREATED);
     }

--- a/src/main/java/org/qrush/brand/restaurant/RestaurantRepository.java
+++ b/src/main/java/org/qrush/brand/restaurant/RestaurantRepository.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface RestaurantRepository extends JpaRepository<Restaurant, UUID> {
-    Optional<Restaurant> findByNameAndBrandId(String name, Long brandId);
+    Optional<Restaurant> findByNameAndBrandId(String name, UUID brandId);
 }

--- a/src/main/java/org/qrush/brand/restaurant/dto/RestaurantDto.java
+++ b/src/main/java/org/qrush/brand/restaurant/dto/RestaurantDto.java
@@ -35,5 +35,5 @@ public class RestaurantDto {
     @DecimalMax(value = "180.0", message = "Longitude must be between -180 and 180")
     private Double longitude;
 
-    private Long brandId;
+    private UUID brandId;
 }

--- a/src/test/java/org/qrush/brand/integration/BrandControllerIntegrationTests.java
+++ b/src/test/java/org/qrush/brand/integration/BrandControllerIntegrationTests.java
@@ -18,6 +18,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -43,7 +44,7 @@ public class BrandControllerIntegrationTests extends AbstractIntegrationTest {
 
         assertNotNull(createdBrand);
         assertEquals("Starbucks", createdBrand.getName());
-        assertEquals(1L, createdBrand.getId());
+        assertNotNull(createdBrand.getId());
     }
 
     @Test
@@ -97,14 +98,14 @@ public class BrandControllerIntegrationTests extends AbstractIntegrationTest {
 
         assertNotNull(brandResponse);
         assertEquals("Starbucks", brandResponse.getName());
-        assertEquals(1L, brandResponse.getId());
+        assertNotNull(brandResponse.getId());
     }
 
     @Test
     @DisplayName("Exception Test: brand does not exist")
     void brandControllerIntegration_GetBrandById_WhenBrandNotFound_ReturnsNotFound() throws Exception {
 
-        ProblemDetail problemDetail = performGetRequestExpectClientError(BRAND_API_ENDPOINT + "/1", ProblemDetail.class);
+        ProblemDetail problemDetail = performGetRequestExpectClientError(BRAND_API_ENDPOINT + "/" + UUID.randomUUID(), ProblemDetail.class);
 
         assertNotNull(problemDetail);
         assertEquals(HttpStatus.NOT_FOUND.value(), problemDetail.getStatus());
@@ -181,7 +182,7 @@ public class BrandControllerIntegrationTests extends AbstractIntegrationTest {
 
         assertNotNull(updatedBrand);
         assertEquals(brandDto.getName(), updatedBrand.getName());
-        assertEquals(1L, updatedBrand.getId());
+        assertNotNull(updatedBrand.getId());
     }
 
     @Test
@@ -189,7 +190,7 @@ public class BrandControllerIntegrationTests extends AbstractIntegrationTest {
     void brandControllerIntegration_UpdateBrand_GivenNullBrandName_ReturnsBadRequest() throws Exception {
         brandDto.setName(null);
 
-        ProblemDetail problemDetail = performPutRequestExpectedClientError(BRAND_API_ENDPOINT + "/" + 1L, brandDto, ProblemDetail.class);
+        ProblemDetail problemDetail = performPutRequestExpectedClientError(BRAND_API_ENDPOINT + "/" + UUID.randomUUID(), brandDto, ProblemDetail.class);
 
         assertNotNull(problemDetail);
         assertEquals(HttpStatus.BAD_REQUEST.value(), problemDetail.getStatus());
@@ -201,7 +202,7 @@ public class BrandControllerIntegrationTests extends AbstractIntegrationTest {
     void brandControllerIntegration_UpdateBrand_GivenEmptyBrandName_ReturnsBadRequest() throws Exception {
         brandDto.setName("");
 
-        ProblemDetail problemDetail = performPutRequestExpectedClientError(BRAND_API_ENDPOINT + "/" + 1L, brandDto, ProblemDetail.class);
+        ProblemDetail problemDetail = performPutRequestExpectedClientError(BRAND_API_ENDPOINT + "/" + UUID.randomUUID(), brandDto, ProblemDetail.class);
 
         assertNotNull(problemDetail);
         assertEquals(HttpStatus.BAD_REQUEST.value(), problemDetail.getStatus());
@@ -225,7 +226,7 @@ public class BrandControllerIntegrationTests extends AbstractIntegrationTest {
     @Test
     @DisplayName("Exception Test: brand does not exist")
     void brandControllerIntegration_UpdateBrand_GivenBrandDoesNotExists_ReturnsNotFound() throws Exception {
-        ProblemDetail problemDetail = performPutRequestExpectedClientError(BRAND_API_ENDPOINT + "/" + 1L, brandDto, ProblemDetail.class);
+        ProblemDetail problemDetail = performPutRequestExpectedClientError(BRAND_API_ENDPOINT + "/" + UUID.randomUUID(), brandDto, ProblemDetail.class);
 
         assertNotNull(problemDetail);
         assertEquals(HttpStatus.NOT_FOUND.value(), problemDetail.getStatus());
@@ -253,7 +254,7 @@ public class BrandControllerIntegrationTests extends AbstractIntegrationTest {
     @Test
     @DisplayName("ExceptionTest: when brand does not exist returns not found")
     void brandControllerIntegration_DeleteBrandById_WhenBrandNotFound_ReturnsNotFound() throws Exception {
-        var url = String.format("%s/%s/delete", BRAND_API_ENDPOINT, 1);
+        var url = String.format("%s/%s/delete", BRAND_API_ENDPOINT, UUID.randomUUID());
 
         var response = performDeleteRequestExpectClientError(url);
 

--- a/src/test/java/org/qrush/brand/integration/RestaurantControllerIntegrationTests.java
+++ b/src/test/java/org/qrush/brand/integration/RestaurantControllerIntegrationTests.java
@@ -13,6 +13,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.geo.Point;
 import org.springframework.http.HttpStatus;
 
+import java.util.UUID;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -205,7 +207,7 @@ public class RestaurantControllerIntegrationTests extends AbstractIntegrationTes
     @Test
     @DisplayName("Exception Test: brand must exist")
     void restaurantControllerIntegration_CreateRestaurant_GivenBrandDoesNotExist_ReturnsNotFound() throws Exception {
-        Long id = savedBrand.getId();
+        UUID id = savedBrand.getId();
         brandRepository.delete(savedBrand);
 
         var invalidBrandUrl = BRAND_API_ENDPOINT + "/" + id + "/restaurant";

--- a/src/test/java/org/qrush/brand/unit/brand/BrandControllerTests.java
+++ b/src/test/java/org/qrush/brand/unit/brand/BrandControllerTests.java
@@ -25,6 +25,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
@@ -115,7 +116,7 @@ class BrandControllerTests {
     //region GETBYID
     @Test
     void brandController_GetBrandById_ReturnsBrandDto() throws Exception {
-        Long id = 1L;
+        UUID id = UUID.randomUUID();
         when(brandService.getBrandById(id)).thenReturn(brandDto);
 
         ResultActions response = mockMvc.perform(get("/brand/" + id));
@@ -126,7 +127,7 @@ class BrandControllerTests {
 
     @Test
     void brandController_GetBrandById_WhenBrandNotFound_ReturnsNotFound() throws Exception {
-        Long id = 1L;
+        UUID id = UUID.randomUUID();
         when(brandService.getBrandById(id)).thenThrow(BrandNotFoundException.class);
 
         ResultActions response = mockMvc.perform(get("/brand/" + id));
@@ -136,7 +137,7 @@ class BrandControllerTests {
 
     @Test
     void brandController_GetBrandById_WhenBrandServiceFails_ReturnsInternalServerError() throws Exception {
-        Long id = 1L;
+        UUID id = UUID.randomUUID();
         when(brandService.getBrandById(id)).thenThrow(ServiceException.class);
 
         ResultActions response = mockMvc.perform(get("/brand/" + id));
@@ -186,7 +187,7 @@ class BrandControllerTests {
     //region PUT
     @Test
     void brandController_UpdateBrand_ReturnsUpdatedBrand() throws Exception {
-        Long id = 1L;
+        UUID id = UUID.randomUUID();
         when(brandService.updateBrand(brandDto, id)).thenReturn(brandDto);
 
         ResultActions response = mockMvc.perform(put("/brand/" + id)
@@ -199,7 +200,7 @@ class BrandControllerTests {
 
     @Test
     void brandController_UpdateBrand_WhenBrandNotFound_ReturnsNotFound() throws Exception {
-        Long id = 1L;
+        UUID id = UUID.randomUUID();
         when(brandService.updateBrand(brandDto, id)).thenThrow(BrandNotFoundException.class);
 
         ResultActions response = mockMvc.perform(put("/brand/" + id)
@@ -211,7 +212,7 @@ class BrandControllerTests {
 
     @Test
     void brandController_UpdateBrand_WhenBrandNameAlreadyExists_ReturnsConflict() throws Exception {
-        Long id = 1L;
+        UUID id = UUID.randomUUID();
         when(brandService.updateBrand(brandDto, id)).thenThrow(BrandAlreadyExists.class);
 
         ResultActions response = mockMvc.perform(put("/brand/" + id)
@@ -223,7 +224,7 @@ class BrandControllerTests {
 
     @Test
     void brandController_UpdateBrand_GivenEmptyJSON_ReturnsBadRequest() throws Exception {
-        Long id = 1L;
+        UUID id = UUID.randomUUID();
 
         ResultActions response = mockMvc.perform(put("/brand/" + id)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -236,7 +237,7 @@ class BrandControllerTests {
 
     @Test
     void brandController_UpdateBrand_GivenInvalidJSON_ReturnsBadRequest() throws Exception {
-        Long id = 1L;
+        UUID id = UUID.randomUUID();
 
         ResultActions response = mockMvc.perform(put("/brand/" + id)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -248,7 +249,7 @@ class BrandControllerTests {
 
     @Test
     void brandController_UpdateBrand_WhenBrandServiceFails_ReturnInternalServerError() throws Exception {
-        Long id = 1L;
+        UUID id = UUID.randomUUID();
         when(brandService.updateBrand(brandDto, id)).thenThrow(ServiceException.class);
 
         ResultActions response = mockMvc.perform(put("/brand/" + id)
@@ -262,30 +263,30 @@ class BrandControllerTests {
     //region DELETE
     @Test
     void brandController_DeleteBrandById_ReturnsNoContent() throws Exception {
-        Long id = 1L;
+        UUID id = UUID.randomUUID();
         doNothing().when(brandService).deleteBrand(id);
 
-        ResultActions response = mockMvc.perform(delete(String.format("/brand/%d/delete", id)));
+        ResultActions response = mockMvc.perform(delete(String.format("/brand/%s/delete", id)));
 
         response.andExpect(MockMvcResultMatchers.status().isNoContent());
     }
 
     @Test
     void brandController_DeleteBrandById_WhenBrandNotFound_ReturnsNotFound() throws Exception {
-        Long id = 1L;
+        UUID id = UUID.randomUUID();
         doThrow(BrandNotFoundException.class).when(brandService).deleteBrand(id);
 
-        ResultActions response = mockMvc.perform(delete(String.format("/brand/%d/delete", id)));
+        ResultActions response = mockMvc.perform(delete(String.format("/brand/%s/delete", id)));
 
         response.andExpect(MockMvcResultMatchers.status().isNotFound());
     }
 
     @Test
     void brandController_DeleteBrandById_WhenBrandServiceFails_ReturnsInternalServerError() throws Exception {
-        Long id = 1L;
+        UUID id = UUID.randomUUID();
         doThrow(ServiceException.class).when(brandService).deleteBrand(id);
 
-        ResultActions response = mockMvc.perform(delete(String.format("/brand/%d/delete", id)));
+        ResultActions response = mockMvc.perform(delete(String.format("/brand/%s/delete", id)));
 
         response.andExpect(MockMvcResultMatchers.status().isInternalServerError());
     }

--- a/src/test/java/org/qrush/brand/unit/brand/BrandMapperTests.java
+++ b/src/test/java/org/qrush/brand/unit/brand/BrandMapperTests.java
@@ -6,6 +6,8 @@ import org.qrush.brand.brand.dto.BrandDto;
 import org.qrush.brand.brand.helpers.BrandMapper;
 import org.qrush.brand.brand.models.Brand;
 
+import java.util.UUID;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class BrandMapperTests {
@@ -19,12 +21,12 @@ public class BrandMapperTests {
         brandMapper = new BrandMapper();
 
         brand = Brand.builder()
-                .id(1L)
+                .id(UUID.randomUUID())
                 .name("Starbucks")
                 .build();
 
         brandDto = BrandDto.builder()
-                .id(2l)
+                .id(UUID.randomUUID())
                 .name("Costa")
                 .build();
 

--- a/src/test/java/org/qrush/brand/unit/brand/BrandRepositoryTests.java
+++ b/src/test/java/org/qrush/brand/unit/brand/BrandRepositoryTests.java
@@ -12,6 +12,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -32,7 +33,6 @@ public class BrandRepositoryTests {
 
         assertNotNull(savedBrand);
         assertNotNull(savedBrand.getId());
-        assertTrue(savedBrand.getId() > 0, "id is greater than 0");
         assertEquals(brand.getName(), savedBrand.getName());
     }
 
@@ -42,7 +42,7 @@ public class BrandRepositoryTests {
                 .name("")
                 .build();
 
-        assertThrows(ConstraintViolationException.class, () -> brandRepository.save(brand));
+        assertThrows(ConstraintViolationException.class, () -> brandRepository.saveAndFlush(brand));
     }
 
     @Test
@@ -51,7 +51,7 @@ public class BrandRepositoryTests {
                 .name(null)
                 .build();
 
-        assertThrows(ConstraintViolationException.class, () -> brandRepository.save(brand));
+        assertThrows(ConstraintViolationException.class, () -> brandRepository.saveAndFlush(brand));
     }
 
     @Test
@@ -65,7 +65,7 @@ public class BrandRepositoryTests {
                 .build();
 
         brandRepository.save(brand1);
-        assertThrows(DataIntegrityViolationException.class, () -> brandRepository.save(brand2));
+        assertThrows(DataIntegrityViolationException.class, () -> brandRepository.saveAndFlush(brand2));
     }
 
     @Test
@@ -101,13 +101,12 @@ public class BrandRepositoryTests {
 
         assertNotNull(foundBrand);
         assertNotNull(foundBrand.getId());
-        assertTrue(foundBrand.getId() > 0, "id is greater than 0");
         assertEquals(brand.getName(), foundBrand.getName());
     }
 
     @Test
     public void brandRepository_FindById_GivenBrandIdDoesntExist_ReturnsNull() {
-        Brand foundBrand = brandRepository.findById(1L).orElse(null);
+        Brand foundBrand = brandRepository.findById(UUID.randomUUID()).orElse(null);
 
         assertNull(foundBrand);
     }
@@ -124,7 +123,6 @@ public class BrandRepositoryTests {
 
         assertNotNull(foundBrand);
         assertNotNull(foundBrand.getId());
-        assertTrue(foundBrand.getId() > 0, "id is greater than 0");
         assertEquals(brand.getName(), foundBrand.getName());
     }
 

--- a/src/test/java/org/qrush/brand/unit/brand/BrandServiceTests.java
+++ b/src/test/java/org/qrush/brand/unit/brand/BrandServiceTests.java
@@ -17,6 +17,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.doNothing;
@@ -70,7 +71,7 @@ class BrandServiceTests {
     //region GET
     @Test
     void brandService_FindById_ReturnsBrandDto() {
-        Long id = 1L;
+        UUID id = UUID.randomUUID();
 
         Brand brand = Brand.builder()
                 .id(id)
@@ -88,7 +89,7 @@ class BrandServiceTests {
 
     @Test
     void brandService_FindById_GivenBrandDoesntExist_ThrowsBrandNotFoundException() {
-        Long id = 1L;
+        UUID id = UUID.randomUUID();
 
         when(brandRepository.findById(id)).thenReturn(Optional.empty());
 
@@ -115,7 +116,7 @@ class BrandServiceTests {
     public void brandService_UpdateBrand_ReturnsBrandDto() {
         Brand brand = Brand.builder()
                 .name("Starbucks")
-                .id(1L)
+                .id(UUID.randomUUID())
                 .build();
 
         BrandDto brandDto = BrandDto.builder()
@@ -123,7 +124,7 @@ class BrandServiceTests {
                 .id(brand.getId())
                 .build();
 
-        when(brandRepository.findById(Mockito.any(Long.class))).thenReturn(Optional.of(brand));
+        when(brandRepository.findById(Mockito.any(UUID.class))).thenReturn(Optional.of(brand));
         when(brandRepository.findByName(Mockito.any(String.class))).thenReturn(Optional.empty());
         when(brandRepository.save(Mockito.any(Brand.class))).thenReturn(brand);
 
@@ -137,9 +138,9 @@ class BrandServiceTests {
     public void brandService_UpdateBrand_GivenBrandDoesNotExist_ThrowsBrandNotFoundException() {
         BrandDto brandDto = BrandDto.builder()
                 .name("Starbucks")
-                .id(1L)
+                .id(UUID.randomUUID())
                 .build();
-        when(brandRepository.findById(Mockito.any(Long.class))).thenReturn(Optional.empty());
+        when(brandRepository.findById(Mockito.any(UUID.class))).thenReturn(Optional.empty());
 
         assertThrows(BrandNotFoundException.class, () -> brandService.updateBrand(brandDto, brandDto.getId()));
     }
@@ -148,7 +149,7 @@ class BrandServiceTests {
     public void brandService_UpdateBrand_GivenBrandNameAlreadyExist_ThrowsBrandAlreadyExistsException() {
         Brand brand = Brand.builder()
                 .name("Starbucks")
-                .id(1L)
+                .id(UUID.randomUUID())
                 .build();
 
         BrandDto brandDto = BrandDto.builder()
@@ -156,7 +157,7 @@ class BrandServiceTests {
                 .id(brand.getId())
                 .build();
 
-        when(brandRepository.findById(Mockito.any(Long.class))).thenReturn(Optional.of(brand));
+        when(brandRepository.findById(Mockito.any(UUID.class))).thenReturn(Optional.of(brand));
         when(brandRepository.findByName(Mockito.any(String.class))).thenReturn(Optional.of(brand));
 
         assertThrows(BrandAlreadyExists.class, () -> brandService.updateBrand(brandDto, brandDto.getId()));
@@ -166,7 +167,7 @@ class BrandServiceTests {
     //region DELETE
     @Test
     public void brandService_DeleteBrand_ReturnsVoid() {
-        Long id = 1L;
+        UUID id = UUID.randomUUID();
         Brand brand = Brand.builder()
                 .name("Starbucks")
                 .id(id)
@@ -182,7 +183,7 @@ class BrandServiceTests {
 
     @Test
     void brandService_DeleteBrand_GivenBrandDoesntExist_ThrowsBrandNotFoundException() {
-        Long id = 1L;
+        UUID id = UUID.randomUUID();
 
         when(brandRepository.findById(id)).thenReturn(Optional.empty());
 

--- a/src/test/java/org/qrush/brand/unit/restaurant/RestaurantControllerTests.java
+++ b/src/test/java/org/qrush/brand/unit/restaurant/RestaurantControllerTests.java
@@ -20,6 +20,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import java.util.Collections;
+import java.util.UUID;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
@@ -43,7 +44,7 @@ public class RestaurantControllerTests {
     @BeforeEach
     public void setup() {
         brand = Brand.builder()
-                .id(1L)
+                .id(UUID.randomUUID())
                 .name("Starbucks")
                 .build();
 

--- a/src/test/java/org/qrush/brand/unit/restaurant/RestaurantMapperTests.java
+++ b/src/test/java/org/qrush/brand/unit/restaurant/RestaurantMapperTests.java
@@ -8,6 +8,8 @@ import org.qrush.brand.restaurant.helpers.RestaurantMapper;
 import org.qrush.brand.restaurant.models.Restaurant;
 import org.springframework.data.geo.Point;
 
+import java.util.UUID;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RestaurantMapperTests {
@@ -22,14 +24,14 @@ public class RestaurantMapperTests {
         restaurantMapper = new RestaurantMapper();
 
         brand = Brand.builder()
-                .id(1L)
+                .id(UUID.randomUUID())
                 .name("Starbucks")
                 .build();
 
         restaurantDto = RestaurantDto.builder()
                 .id(null)
                 .name("Starbucks Ipswich")
-                .brandId(1L)
+                .brandId(UUID.randomUUID())
                 .address("123 Street")
                 .latitude(1.0)
                 .longitude(50.0)

--- a/src/test/java/org/qrush/brand/unit/restaurant/RestaurantRepositoryTests.java
+++ b/src/test/java/org/qrush/brand/unit/restaurant/RestaurantRepositoryTests.java
@@ -15,6 +15,8 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.geo.Point;
 
+import java.util.UUID;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
@@ -35,7 +37,7 @@ public class RestaurantRepositoryTests {
     public void setup() {
         brand = Brand.builder()
                 .name("Starbucks")
-                .id(1L)
+                .id(UUID.randomUUID())
                 .build();
 
         restaurant = Restaurant.builder()

--- a/src/test/java/org/qrush/brand/unit/restaurant/RestaurantServiceTests.java
+++ b/src/test/java/org/qrush/brand/unit/restaurant/RestaurantServiceTests.java
@@ -19,6 +19,7 @@ import org.qrush.brand.restaurant.models.Restaurant;
 import org.springframework.data.geo.Point;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
@@ -41,7 +42,7 @@ public class RestaurantServiceTests {
     @InjectMocks
     private RestaurantService restaurantService;
 
-    private Long brandId;
+    private UUID brandId;
     private BrandDto brandDto;
     private Brand brand;
     private RestaurantDto restaurantDto;
@@ -49,7 +50,7 @@ public class RestaurantServiceTests {
 
     @BeforeEach
     public void setup() {
-        brandId = 1L;
+        brandId = UUID.randomUUID();
         brand = Brand.builder()
                 .id(brandId)
                 .name("Starbucks")
@@ -78,7 +79,7 @@ public class RestaurantServiceTests {
     //region CREATE
     @Test
     public void restaurantService_CreateRestaurant_ReturnsRestaurantDto() {
-        when(brandService.getBrandById(Mockito.anyLong())).thenReturn(brandDto);
+        when(brandService.getBrandById(Mockito.any())).thenReturn(brandDto);
         when(restaurantRepository.save(Mockito.any(Restaurant.class))).thenReturn(restaurant);
 
         RestaurantDto savedRestaurantDto = restaurantService.createRestaurant(restaurantDto);
@@ -93,15 +94,15 @@ public class RestaurantServiceTests {
 
     @Test
     public void restaurantService_CreateRestaurant_GivenBrandDoesNotExist_ThrowsNotFoundException() {
-        when(brandService.getBrandById(Mockito.anyLong())).thenThrow(BrandNotFoundException.class);
+        when(brandService.getBrandById(Mockito.any())).thenThrow(BrandNotFoundException.class);
 
         assertThrows(BrandNotFoundException.class, () -> restaurantService.createRestaurant(restaurantDto));
     }
 
     @Test
     public void restaurantService_CreateBrand_GivenRestaurantNameAlreadyExistsForBrand_ThrowsRestaurantAlreadyExists() {
-        when(brandService.getBrandById(Mockito.anyLong())).thenReturn(brandDto);
-        when(restaurantRepository.findByNameAndBrandId(Mockito.anyString(), Mockito.anyLong())).thenReturn(Optional.of(restaurant));
+        when(brandService.getBrandById(Mockito.any())).thenReturn(brandDto);
+        when(restaurantRepository.findByNameAndBrandId(Mockito.anyString(), Mockito.any())).thenReturn(Optional.of(restaurant));
 
         assertThrows(RestaurantAlreadyExists.class, () -> restaurantService.createRestaurant(restaurantDto));
     }


### PR DESCRIPTION
### General
Refactor Brand Id type from Long to UUID to follow best practice for IDs in postgres.

[CPG-43: Switch Brand Id to GUID](https://qrush.atlassian.net/browse/CPG-43)

### Testing
Covered by unit and integration tests

### SAT
I spun up the service locally in docker, created a new brand with name "Costa" then retrieved entry with GET endpoint:

Post Brands Request
POST _/v1/brand/_

{
"name": "Costa"
}
Response
Status: 201 Created
Body

```
{
"id": "c6992e46-312e-4834-bf19-5bf4cdad8d90",
"name": "Costa"
}
```

Get Brands Request
GET _/v1/brand/c6992e46-312e-4834-bf19-5bf4cdad8d90_

Response
Status 200 Ok
Body

```
{
"id": "c6992e46-312e-4834-bf19-5bf4cdad8d90",
"name": "Costa"
}
```